### PR TITLE
Fixed reading ushort at the end of A2S_INFO response

### DIFF
--- a/QueryMaster/Parser.cs
+++ b/QueryMaster/Parser.cs
@@ -63,7 +63,7 @@ namespace QueryMaster
             ushort num=0;
 
             CurrentPosition++;
-            if (CurrentPosition + 3 > LastPosition)
+            if (CurrentPosition + 1 > LastPosition)
                 throw new ParseException("Unable to parse bytes to ushort.");
             
             if (!BitConverter.IsLittleEndian)


### PR DESCRIPTION
Fixed wrong condition for checking last position of reading ushort. This problem cause an exception when ushort placed at the end of A2S_INFO response.
```
Unhandled exception. QueryMaster.ParseException: Unable to parse bytes to ushort.
   at QueryMaster.Parser.ReadUShort()
   at QueryMaster.GameServer.Server.Current(Byte[] data)
   at QueryMaster.GameServer.Server.getInfo()
   at QueryMaster.QueryMasterBase.Invoke[T](Func`1 method, Int32 attempts, AttemptCallback attemptcallback, Boolean throwExceptions)
   at QueryMaster.GameServer.Server.GetInfo(AttemptCallback callback)
```
